### PR TITLE
correct type.

### DIFF
--- a/src/services.lisp
+++ b/src/services.lisp
@@ -28,7 +28,7 @@
 ;;; Accounts
 
 (defclass <account> ()
-  ((service :reader service :initarg :service :type string)
+  ((service :reader service :initarg :service :type <service>)
    (username :reader username :initarg :username :type string)
    (password :reader password :initarg :password :type string)))
 


### PR DESCRIPTION
Hi, 
This just corrects a type specifier. On SBCL slot types are not checked unless safety 3.
Thanks.